### PR TITLE
script changes for use with python3 and awscli v2

### DIFF
--- a/nginx-ha-notify
+++ b/nginx-ha-notify
@@ -23,31 +23,34 @@ TYPE=$1
 NAME=$2
 STATE=$3
 
+#Get aws cli v2 token for metadata requests
+TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+
 #Determine the internal or private dns name of the instance
-LOCAL_INTERNAL_DNS_NAME=`wget -q -O - http://169.254.169.254/latest/meta-data/local-hostname`
-LOCAL_INTERNAL_DNS_NAME=`echo $LOCAL_INTERNAL_DNS_NAME | sed -e 's/% //g'`
+LOCAL_IP=`curl -s http://169.254.169.254/latest/meta-data/local-ipv4 -H "X-aws-ec2-metadata-token: $TOKEN"`
 
 #OTHER_INSTANCE_DNS_NAME is the other node than this one, default assignment is HA_NODE_1
-OTHER_INSTANCE_DNS_NAME=$HA_NODE_1
+OTHER_IP=$HA_NODE_1
+
 
 #Use LOCAL_INTERNAL_DNS_NAME to determine which node this is and to set the Other Node name
-if [ "$HA_NODE_1" = "$LOCAL_INTERNAL_DNS_NAME" ]
+if [ "$HA_NODE_1" = "$LOCAL_IP" ]
 then
-    OTHER_INSTANCE_DNS_NAME=$HA_NODE_2
+    OTHER_IP=$HA_NODE_2
 fi
 
 #Get the local instance ID
-INSTANCE_ID=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`
+INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $TOKEN"`
 INSTANCE_ID=`echo $INSTANCE_ID | sed -e 's/% //g'`
 
 #Get the instance ID of the other node
-OTHER_INSTANCE_ID=`aws ec2 describe-instances --filter "Name=private-dns-name,Values=$OTHER_INSTANCE_DNS_NAME" | /usr/bin/python -c 'import json,sys;obj=json.load(sys.stdin); print obj["Reservations"][0]["Instances"][0]["InstanceId"]'`
+OTHER_INSTANCE_ID=`aws ec2 describe-instances --filter "Name=private-ip-address,Values=$OTHER_IP" | /usr/bin/python -c 'import json,sys;obj=json.load(sys.stdin); print(obj["Reservations"][0]["Instances"][0]["InstanceId"])'`
 
 #Get the ASSOCIATION_ID of the ElasticIP to the Instance
-ASSOCIATION_ID=`aws ec2 describe-addresses --allocation-id $ALLOCATION_ID | /usr/bin/python -c 'import json,sys;obj=json.load(sys.stdin); print obj["Addresses"][0]["AssociationId"]'`
+ASSOCIATION_ID=`aws ec2 describe-addresses --allocation-id $ALLOCATION_ID | /usr/bin/python -c 'import json,sys;obj=json.load(sys.stdin); print(obj["Addresses"][0]["AssociationId"])'`
 
 #Get the INSTANCE_ID of the system the ElasticIP is associated with
-EIP_INSTANCE=`aws ec2 describe-addresses --allocation-id $ALLOCATION_ID | /usr/bin/python -c 'import json,sys;obj=json.load(sys.stdin); print obj["Addresses"][0]["InstanceId"]'`
+EIP_INSTANCE=`aws ec2 describe-addresses --allocation-id $ALLOCATION_ID | /usr/bin/python -c 'import json,sys;obj=json.load(sys.stdin); print(obj["Addresses"][0]["InstanceId"])'`
 
 STATEFILE=/var/run/nginx-ha-keepalived.state
 
@@ -74,6 +77,7 @@ case $STATE in
                   exit 0
                   ;;
         *)        logger -t nginx-ha-keepalived "Unknown state: '$STATE'"
+                  echo "unknown state $STATE"
                   exit 1
                   ;;
 esac

--- a/nginx-ha-notify
+++ b/nginx-ha-notify
@@ -77,7 +77,6 @@ case $STATE in
                   exit 0
                   ;;
         *)        logger -t nginx-ha-keepalived "Unknown state: '$STATE'"
-                  echo "unknown state $STATE"
                   exit 1
                   ;;
 esac


### PR DESCRIPTION
For awscli v2 I've added the token header to query for instance metadata.

For python3 I've changed the print function to use parenthesis for v3.

I've also changed the local dns comparison to compare using local ipv4.

I also think that it's important to say on the documentation that when using OS that only has python3 to create a symbolic link like this:

ln -s /usr/bin/python3 /usr/bin/python